### PR TITLE
stacks gcp guide: update command snippets

### DIFF
--- a/cluster/examples/gcp-credentials.sh
+++ b/cluster/examples/gcp-credentials.sh
@@ -6,8 +6,8 @@
 # gcloud is required for use and must be configured with privileges to perform these tasks
 #
 set -e -o pipefail
-ROLES=(roles/iam.serviceAccountUser roles/cloudsql.admin roles/container.admin roles/redis.admin)
-SERVICES=(container.googleapis.com sqladmin.googleapis.com redis.googleapis.com)
+ROLES=(roles/iam.serviceAccountUser roles/cloudsql.admin roles/container.admin roles/redis.admin roles/compute.networkAdmin)
+SERVICES=(container.googleapis.com sqladmin.googleapis.com redis.googleapis.com compute.googleapis.com)
 KEYFILE=crossplane-gcp-provider-key.json
 RAND=$RANDOM
 

--- a/docs/cloud-providers/gcp/gcp-provider.md
+++ b/docs/cloud-providers/gcp/gcp-provider.md
@@ -62,6 +62,9 @@ gcloud --project $EXAMPLE_PROJECT_ID services enable sqladmin.googleapis.com
 # enable Redis API
 gcloud --project $EXAMPLE_PROJECT_ID services enable redis.googleapis.com
 
+# enable Compute API
+gcloud --project $EXAMPLE_PROJECT_ID services enable compute.googleapis.com
+
 # enable Additional APIs needed for the example or project
 # See `gcloud services list` for a complete list
 
@@ -79,6 +82,7 @@ gcloud projects add-iam-policy-binding $EXAMPLE_PROJECT_ID --member "serviceAcco
 gcloud projects add-iam-policy-binding $EXAMPLE_PROJECT_ID --member "serviceAccount:$EXAMPLE_SA" --role="roles/cloudsql.admin"
 gcloud projects add-iam-policy-binding $EXAMPLE_PROJECT_ID --member "serviceAccount:$EXAMPLE_SA" --role="roles/container.admin"
 gcloud projects add-iam-policy-binding $EXAMPLE_PROJECT_ID --member "serviceAccount:$EXAMPLE_SA" --role="roles/redis.admin"
+gcloud projects add-iam-policy-binding $EXAMPLE_PROJECT_ID --member "serviceAccount:$EXAMPLE_SA" --role="roles/compute.networkAdmin"
 ```
 
 ## Option 2: GCP Console in a Web Browser
@@ -100,6 +104,7 @@ Create a GCP example project which we will use to host our example GKE cluster, 
     - `Service Account User`
     - `Cloud SQL Admin`
     - `Kubernetes Engine Admin`
+    - `Compute Network Admin`
   - Click `Create` button
     - This should advance to the next section `3 Grant users access to this service account (optional)`
   - We don't need to assign any user or admin roles to this account for the example purposes, so you can leave following two fields blank:
@@ -121,6 +126,9 @@ Create a GCP example project which we will use to host our example GKE cluster, 
   - Click `Enable`
 - Enable `Cloud Memorystore for Redis`
   - Navigate to [Cloud Memorystore for Redis](https://console.developers.google.com/apis/api/redis.googleapis.com/overview)
+  - Click `Enable`
+- Enable `Compute Engine API`
+  - Navigate to [Compute Engine API](https://console.developers.google.com/apis/api/compute.googleapis.com/overview)
   - Click `Enable`
 
 ### Enable Billing


### PR DESCRIPTION
Use cat to write the command snippets into their own files
and run kubectl apply. PROJECT_ID env var is used in these
resources.
Update gcp-credentials.sh with Network role and Compute service.

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml